### PR TITLE
Add GPTJ, Calendar, Wikipedia Search, Machine Translation, Calculator

### DIFF
--- a/toolformer_pytorch/prompts.py
+++ b/toolformer_pytorch/prompts.py
@@ -1,0 +1,148 @@
+calculator_prompt = """
+Your task is to add calls to a
+Calculator API to a piece of text.
+The calls should help you get
+information required to complete the
+text. You can call the API by writing
+"[Calculator(expression)]" where
+"expression" is the expression to be
+computed. Here are some examples of API
+calls:
+Input: The number in the next term is 18
++ 12 x 3 = 54.
+Output: The number in the next term is
+18 + 12 x 3 = [Calculator(18 + 12 * 3)]
+54.
+Input: The population is 658,893 people.
+This is 11.4% of the national average of
+5,763,868 people.
+Output: The population is 658,893 people.
+This is 11.4% of the national average of
+[Calculator(658,893 / 11.4%)] 5,763,868
+people.
+Input: A total of 252 qualifying matches
+were played, and 723 goals were scored
+(an average of 2.87 per match). This is
+three times less than the 2169 goals
+last year.
+Output: A total of 252 qualifying
+matches were played, and 723 goals were
+scored (an average of [Calculator(723
+/ 252)] 2.87 per match). This is twenty
+goals more than the [Calculator(723 -
+20)] 703 goals last year.
+Input: I went to Paris in 1994 and
+stayed there until 2011, so in total,
+it was 17 years.
+Output: I went to Paris in 1994 and
+stayed there until 2011, so in total, it
+was [Calculator(2011 - 1994)] 17 years.
+Input: From this, we have 4 * 30 minutes
+= 120 minutes.
+Output: From this, we have 4 * 30
+minutes = [Calculator(4 * 30)] 120
+minutes.
+Input: x
+Output:
+"""
+
+wikipedia_search_prompt = """
+Your task is to complete a given piece
+of text. You can use a Wikipedia Search
+API to look up information. You can do
+so by writing "[WikiSearch(term)]" where
+"term" is the search term you want to
+look up. Here are some examples of API
+calls:
+Input: The colors on the flag of Ghana
+have the following meanings: red is for
+the blood of martyrs, green for forests,
+and gold for mineral wealth.
+Output: The colors on the flag of Ghana
+have the following meanings: red is for
+[WikiSearch("Ghana flag red meaning")]
+the blood of martyrs, green for forests,
+and gold for mineral wealth.
+Input: But what are the risks during
+production of nanomaterials? Some
+nanomaterials may give rise to various
+kinds of lung damage.
+Output: But what are the risks
+during production of nanomaterials?
+[WikiSearch("nanomaterial production
+risks")] Some nanomaterials may give
+rise to various kinds of lung damage.
+Input: Metformin is the first-line drug
+for patients with type 2 diabetes and
+obesity.
+Output: Metformin is the first-line drug
+for [WikiSearch("Metformin first-line
+drug")] patients with type 2 diabetes
+and obesity.
+Input: x
+Output:
+"""
+
+machine_translation_prompt = """
+Your task is to complete a given piece
+of text by using a Machine Translation
+API.
+You can do so by writing "[MT(text)]"
+where text is the text to be translated
+into English.
+Here are some examples:
+Input: He has published one book: O
+homem suprimido (“The Supressed Man”)
+Output: He has published one book: O
+homem suprimido [MT(O homem suprimido)]
+(“The Supressed Man”)
+Input: In Morris de Jonge’s Jeschuah,
+der klassische jüdische Mann, there is a
+description of a Jewish writer
+Output: In Morris de Jonge’s Jeschuah,
+der klassische jüdische Mann [MT(der
+klassische jüdische Mann)], there is a
+description of a Jewish writer
+Input: 南 京 高 淳 县 住 房 和 城 乡 建 设 局 城 市 新
+区 设 计 a plane of reference Gaochun is
+one of seven districts of the provincial
+capital Nanjing
+Output: [MT(南京高淳县住房和城乡建设局 城市新
+区 设 计)] a plane of reference Gaochun is
+one of seven districts of the provincial
+capital Nanjing
+Input: x
+Output:
+"""
+
+calendar_prompt = """
+Your task is to add calls to a Calendar
+API to a piece of text. The API calls
+should help you get information required
+to complete the text. You can call the
+API by writing "[Calendar()]" Here are
+some examples of API calls:
+Input: Today is the first Friday of the
+year.
+Output: Today is the first [Calendar()]
+Friday of the year.
+Input: The president of the United
+States is Joe Biden.
+Output: The president of the United
+States is [Calendar()] Joe Biden.
+Input: The current day of the week is
+Wednesday.
+Output: The current day of the week is
+[Calendar()] Wednesday.
+Input: The number of days from now until
+Christmas is 30.
+Output: The number of days from now
+until Christmas is [Calendar()] 30.
+Input: The store is never open on the
+weekend, so today it is closed.
+Output: The store is never open on the
+weekend, so today [Calendar()] it is
+closed.
+Input: x
+Output:
+"""

--- a/toolformer_pytorch/prompts.py
+++ b/toolformer_pytorch/prompts.py
@@ -1,148 +1,66 @@
 calculator_prompt = """
-Your task is to add calls to a
-Calculator API to a piece of text.
-The calls should help you get
-information required to complete the
-text. You can call the API by writing
-"[Calculator(expression)]" where
-"expression" is the expression to be
-computed. Here are some examples of API
-calls:
-Input: The number in the next term is 18
-+ 12 x 3 = 54.
-Output: The number in the next term is
-18 + 12 x 3 = [Calculator(18 + 12 * 3)]
-54.
-Input: The population is 658,893 people.
-This is 11.4% of the national average of
-5,763,868 people.
-Output: The population is 658,893 people.
-This is 11.4% of the national average of
-[Calculator(658,893 / 11.4%)] 5,763,868
-people.
-Input: A total of 252 qualifying matches
-were played, and 723 goals were scored
-(an average of 2.87 per match). This is
-three times less than the 2169 goals
-last year.
-Output: A total of 252 qualifying
-matches were played, and 723 goals were
-scored (an average of [Calculator(723
-/ 252)] 2.87 per match). This is twenty
-goals more than the [Calculator(723 -
-20)] 703 goals last year.
-Input: I went to Paris in 1994 and
-stayed there until 2011, so in total,
-it was 17 years.
-Output: I went to Paris in 1994 and
-stayed there until 2011, so in total, it
-was [Calculator(2011 - 1994)] 17 years.
-Input: From this, we have 4 * 30 minutes
-= 120 minutes.
-Output: From this, we have 4 * 30
-minutes = [Calculator(4 * 30)] 120
-minutes.
+Your task is to add calls to a Calculator API to a piece of text.
+The calls should help you get information required to complete the text. 
+You can call the API by writing "[Calculator(expression)]" where "expression" is the expression to be computed. 
+Here are some examples of API calls:
+Input: The number in the next term is 18 + 12 x 3 = 54.
+Output: The number in the next term is 18 + 12 x 3 = [Calculator(18 + 12 * 3)] 54.
+Input: The population is 658,893 people. This is 11.4% of the national average of 5,763,868 people.
+Output: The population is 658,893 people. This is 11.4% of the national average of [Calculator(658,893 / 11.4%)] 5,763,868 people.
+Input: A total of 252 qualifying matches were played, and 723 goals were scored (an average of 2.87 per match). This is three times less than the 2169 goals last year.
+Output: A total of 252 qualifying matches were played, and 723 goals were scored (an average of [Calculator(723 / 252)] 2.87 per match). This is twenty goals more than the [Calculator(723 - 20)] 703 goals last year.
+Input: I went to Paris in 1994 and stayed there until 2011, so in total, it was 17 years.
+Output: I went to Paris in 1994 and stayed there until 2011, so in total, it was [Calculator(2011 - 1994)] 17 years.
+Input: From this, we have 4 * 30 minutes = 120 minutes.
+Output: From this, we have 4 * 30 minutes = [Calculator(4 * 30)] 120 minutes.
 Input: x
 Output:
 """
 
 wikipedia_search_prompt = """
-Your task is to complete a given piece
-of text. You can use a Wikipedia Search
-API to look up information. You can do
-so by writing "[WikiSearch(term)]" where
-"term" is the search term you want to
-look up. Here are some examples of API
-calls:
-Input: The colors on the flag of Ghana
-have the following meanings: red is for
-the blood of martyrs, green for forests,
-and gold for mineral wealth.
-Output: The colors on the flag of Ghana
-have the following meanings: red is for
-[WikiSearch("Ghana flag red meaning")]
-the blood of martyrs, green for forests,
-and gold for mineral wealth.
-Input: But what are the risks during
-production of nanomaterials? Some
-nanomaterials may give rise to various
-kinds of lung damage.
-Output: But what are the risks
-during production of nanomaterials?
-[WikiSearch("nanomaterial production
-risks")] Some nanomaterials may give
-rise to various kinds of lung damage.
-Input: Metformin is the first-line drug
-for patients with type 2 diabetes and
-obesity.
-Output: Metformin is the first-line drug
-for [WikiSearch("Metformin first-line
-drug")] patients with type 2 diabetes
-and obesity.
+Your task is to complete a given piece of text. 
+You can use a Wikipedia Search API to look up information. 
+You can do so by writing "[WikiSearch(term)]" where "term" is the search term you want to look up. 
+Here are some examples of API calls:
+Input: The colors on the flag of Ghana have the following meanings: red is for the blood of martyrs, green for forests, and gold for mineral wealth.
+Output: The colors on the flag of Ghana have the following meanings: red is for [WikiSearch("Ghana flag red meaning")] the blood of martyrs, green for forests, and gold for mineral wealth.
+Input: But what are the risks during production of nanomaterials? Some nanomaterials may give rise to various kinds of lung damage.
+Output: But what are the risks during production of nanomaterials? [WikiSearch("nanomaterial production risks")] Some nanomaterials may give rise to various kinds of lung damage.
+Input: Metformin is the first-line drug for patients with type 2 diabetes and obesity.
+Output: Metformin is the first-line drug for [WikiSearch("Metformin first-line drug")] patients with type 2 diabetes and obesity.
 Input: x
 Output:
 """
 
 machine_translation_prompt = """
-Your task is to complete a given piece
-of text by using a Machine Translation
-API.
-You can do so by writing "[MT(text)]"
-where text is the text to be translated
-into English.
+Your task is to complete a given piece of text by using a Machine Translation API.
+You can do so by writing "[MT(text)]" where text is the text to be translated into English.
 Here are some examples:
-Input: He has published one book: O
-homem suprimido (“The Supressed Man”)
-Output: He has published one book: O
-homem suprimido [MT(O homem suprimido)]
-(“The Supressed Man”)
-Input: In Morris de Jonge’s Jeschuah,
-der klassische jüdische Mann, there is a
-description of a Jewish writer
-Output: In Morris de Jonge’s Jeschuah,
-der klassische jüdische Mann [MT(der
-klassische jüdische Mann)], there is a
-description of a Jewish writer
-Input: 南 京 高 淳 县 住 房 和 城 乡 建 设 局 城 市 新
-区 设 计 a plane of reference Gaochun is
-one of seven districts of the provincial
-capital Nanjing
-Output: [MT(南京高淳县住房和城乡建设局 城市新
-区 设 计)] a plane of reference Gaochun is
-one of seven districts of the provincial
-capital Nanjing
+Input: He has published one book: O homem suprimido (“The Supressed Man”)
+Output: He has published one book: O homem suprimido [MT(O homem suprimido)] (“The Supressed Man”)
+Input: In Morris de Jonge’s Jeschuah, der klassische jüdische Mann, there is a description of a Jewish writer
+Output: In Morris de Jonge’s Jeschuah, der klassische jüdische Mann [MT(der klassische jüdische Mann)], there is a description of a Jewish writer
+Input: 南 京 高 淳 县 住 房 和 城 乡 建 设 局 城 市 新 区 设 计 a plane of reference Gaochun is one of seven districts of the provincial capital Nanjing
+Output: [MT(南京高淳县住房和城乡建设局 城市新 区 设 计)] a plane of reference Gaochun is one of seven districts of the provincial capital Nanjing
 Input: x
 Output:
 """
 
 calendar_prompt = """
-Your task is to add calls to a Calendar
-API to a piece of text. The API calls
-should help you get information required
-to complete the text. You can call the
-API by writing "[Calendar()]" Here are
-some examples of API calls:
-Input: Today is the first Friday of the
-year.
-Output: Today is the first [Calendar()]
-Friday of the year.
-Input: The president of the United
-States is Joe Biden.
-Output: The president of the United
-States is [Calendar()] Joe Biden.
-Input: The current day of the week is
-Wednesday.
-Output: The current day of the week is
-[Calendar()] Wednesday.
-Input: The number of days from now until
-Christmas is 30.
-Output: The number of days from now
-until Christmas is [Calendar()] 30.
-Input: The store is never open on the
-weekend, so today it is closed.
-Output: The store is never open on the
-weekend, so today [Calendar()] it is
-closed.
+Your task is to add calls to a Calendar API to a piece of text. 
+The API calls should help you get information required to complete the text. 
+You can call the API by writing "[Calendar()]" 
+Here are some examples of API calls:
+Input: Today is the first Friday of the year.
+Output: Today is the first [Calendar()] Friday of the year.
+Input: The president of the United States is Joe Biden.
+Output: The president of the United States is [Calendar()] Joe Biden.
+Input: The current day of the week is Wednesday.
+Output: The current day of the week is [Calendar()] Wednesday.
+Input: The number of days from now until Christmas is 30.
+Output: The number of days from now until Christmas is [Calendar()] 30.
+Input: The store is never open on the weekend, so today it is closed.
+Output: The store is never open on the weekend, so today [Calendar()] it is closed.
 Input: x
 Output:
 """

--- a/toolformer_pytorch/toolformer_pytorch.py
+++ b/toolformer_pytorch/toolformer_pytorch.py
@@ -190,7 +190,6 @@ class Toolformer(nn.Module):
         dim_head=64, 
         heads=8, 
         ff_mult=4,
-        dropout=0.
     ):
         super().__init__()
 
@@ -212,7 +211,6 @@ if __name__ == "__main__":
         dim_head = 64,
         heads = 8,
         ff_mult = 4,
-        dropout = 0.
     )
     tokens = torch.randint(0, 20000, (1, 512))
     logits = toolformer(tokens)

--- a/toolformer_pytorch/toolformer_pytorch.py
+++ b/toolformer_pytorch/toolformer_pytorch.py
@@ -1,6 +1,6 @@
 import torch
 from torch import nn, einsum
-
+import torch.nn.functional as F
 from einops import rearrange
 
 # helpers
@@ -8,7 +8,73 @@ from einops import rearrange
 def exists(val):
     return val is not None
 
+
+# normalization
+# Layernorm without bias
+
+
+class LayerNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gamma = nn.Parameter(torch.ones(dim))
+        self.register_buffer("beta", torch.zeros(dim))
+
+    def forward(self, x):
+        return F.layer_norm(x, x.shape[-1:], self.gamma, self.beta)
+
+
+# rotary positional embedding
+# https://arxiv.org/abs/2104.09864
+
+
+class RotaryEmbedding(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        inv_freq = 1.0 / (10000 ** (torch.arange(0, dim, 2).float() / dim))
+        self.register_buffer("inv_freq", inv_freq)
+
+    def forward(self, max_seq_len, *, device):
+        seq = torch.arange(max_seq_len, device=device, dtype=self.inv_freq.dtype)
+        freqs = einsum("i , j -> i j", seq, self.inv_freq)
+        return torch.cat((freqs, freqs), dim=-1)
+
+
+def rotate_half(x):
+    x = rearrange(x, "... (j d) -> ... j d", j=2)
+    x1, x2 = x.unbind(dim=-2)
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(pos, t):
+    return (t * pos.cos()) + (rotate_half(t) * pos.sin())
+
+
+# FeedFoward
+
+
+class FeedForward(nn.Module):
+    def __init__(
+        self, 
+        dim, 
+        ff_mult=4, 
+        dropout=0.
+    ):
+        super().__init__()
+        ff_inner_dim = int(dim * ff_mult)
+
+        self.ff_out = nn.Sequential(
+            nn.Linear(dim, ff_inner_dim),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(ff_inner_dim, dim),
+        )
+
+    def forward(self, x):
+        return self.ff_out(x)
+
+
 # all we need
+
 
 class Attention(nn.Module):
     def __init__(
@@ -22,6 +88,7 @@ class Attention(nn.Module):
         super().__init__()
         self.heads = heads
         self.scale = dim_head ** -0.5
+        self.rotary_emb = RotaryEmbedding(dim_head)
         self.causal = causal
         inner_dim = dim_head * heads
 
@@ -31,12 +98,24 @@ class Attention(nn.Module):
         self.to_kv = nn.Linear(dim, inner_dim * 2, bias = False)
         self.to_out = nn.Linear(inner_dim, dim, bias = False)
 
+        self.attn_dropout = nn.Dropout(dropout)
+
+        self.register_buffer("pos_emb", None, persistent=False)
+
+    def get_rotary_embedding(self, n, device):
+        if self.pos_emb is not None and self.pos_emb.shape[-2] >= n:
+            return self.pos_emb[:n]
+
+        pos_emb = self.rotary_emb(n, device=device)
+        self.register_buffer("pos_emb", pos_emb, persistent=False)
+        return pos_emb
+
     def forward(
         self,
         x,
         mask = None
     ):
-        b, n, _, device = *x.shape, x.device
+        b, n, _, device, h = *x.shape, x.device, self.heads
 
         # prenorm
 
@@ -49,6 +128,13 @@ class Attention(nn.Module):
         # split for multi-headed attention
 
         q, k, v = map(lambda t: rearrange(t, 'b n (h d) -> b h n d', h = self.heads), (q, k, v))
+
+        # rotary embeddings
+
+        positions = self.get_rotary_embedding(n, device)
+        q, k = map(lambda t: apply_rotary_pos_emb(positions, t), (q, k))
+
+        # scale
 
         q = q * self.scale
 
@@ -79,13 +165,89 @@ class Attention(nn.Module):
         out = rearrange(out, 'b h n d -> b n (h d)')
         return self.to_out(out)
 
+
+# GPTJ Block
+
+
+class GPTJBlock(nn.Module):
+    def __init__(
+        self, 
+        dim, 
+        dim_head=64, 
+        heads=8, 
+        ff_mult=4, 
+        dropout=0.
+    ):
+        super().__init__()
+        self.attn = Attention(dim, dim_head=dim_head, heads=heads)
+        self.ffn = FeedForward(dim, ff_mult=ff_mult, dropout=dropout)
+
+    def forward(self, x):
+        return self.ffn(x) + self.attn(x)
+
+
+# Transformer
+
+
+class Transformer(nn.Module):
+    def __init__(
+        self, 
+        dim, 
+        depth, 
+        heads, 
+        dim_head, 
+        ff_mult=4,
+        dropout=0., 
+    ):
+        super().__init__()
+        self.layers = nn.ModuleList([])
+
+        for _ in range(depth):
+            self.layers.append(
+                GPTJBlock(dim, dim_head=dim_head, heads=heads, ff_mult=ff_mult, dropout=dropout), 
+            )
+
+    def forward(self, x):
+        for block in self.layers:
+            x = block(x) + x
+        return x
+
+
 # classes
 
 class Toolformer(nn.Module):
     def __init__(
-        self
+        self, 
+        dim, 
+        num_tokens, 
+        depth, 
+        dim_head=64, 
+        heads=8, 
+        ff_mult=4,
+        dropout=0.
     ):
         super().__init__()
 
+        self.emb = nn.Embedding(num_tokens, dim)
+        self.transformer = Transformer(dim, depth, heads, dim_head, ff_mult, dropout)
+        self.to_logits = nn.Linear(dim, num_tokens)
+
     def forward(self, x):
+        x = self.emb(x)
+        x = self.transformer(x)
+        x = self.to_logits(x)
         return x
+
+if __name__ == "__main__":
+    toolformer = Toolformer(
+        num_tokens = 20000,
+        dim = 512,
+        depth = 6,
+        dim_head = 64,
+        heads = 8,
+        ff_mult = 4,
+        dropout = 0.
+    )
+    tokens = torch.randint(0, 20000, (1, 512))
+    logits = toolformer(tokens)
+    print(logits.shape)

--- a/toolformer_pytorch/tools.py
+++ b/toolformer_pytorch/tools.py
@@ -105,7 +105,7 @@ def Calculator(input_query: str):
     for c in operators.keys():
         left, operator, right = input_query.partition(c)
         if operator in operators:
-            return operators[operator](Calculator(left), Calculator(right))
+            return round(operators[operator](Calculator(left), Calculator(right)), 2)
 
 
 # Other Optional Tools

--- a/toolformer_pytorch/tools.py
+++ b/toolformer_pytorch/tools.py
@@ -3,31 +3,24 @@ import calendar
 import wolframalpha
 import datetime
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+from operator import pow, truediv, mul, add, sub  
 
-# Optional Tool imports
+# Optional imports
 from googleapiclient.discovery import build
-
+    
 
 '''
-Calculator
+Calendar
 
-pip install wolframalpha
+Uses Python's datetime and calendar libraries to retrieve the current date.
 
-Uses Wolfram Alpha API to calculate input query.
+input - None
 
-input_query - A string, the input query (e.g. "what is 2 + 2?")
-
-output - A string, the answer to the input query
-
-wolfarm_alpha_appid - your Wolfram Alpha API key
+output - A string, the current date.
 '''
-def Calculator(input_query: str):
-    wolfram_alpha_appid = 'YOUR_WOLFRAM_ALPHA_APPID'
-    wolfram_client = wolframalpha.Client(wolfram_alpha_appid)
-    res = wolfram_client.query(input_query)
-    assumption = next(res.pods).text
-    answer = next(res.results).text
-    return f'Assumption: {assumption} \nAnswer: {answer}'
+def Calendar():
+    now = datetime.datetime.now()
+    return f'Today is {calendar.day_name[now.weekday()]}, {calendar.month_name[now.month]} {now.day}, {now.year}.'
 
 
 '''
@@ -90,23 +83,55 @@ def MT(input_query: str):
 
 
 '''
-Calendar
+Calculator
 
-Uses Python's datetime and calendar libraries to retrieve the current date.
+Calculates the result of a mathematical expression.
 
-output - A string, the current date.
+input_query - A string, the input query (e.g. "400/1400")
+
+output - A float, the result of the calculation
+
+Adapted from: https://levelup.gitconnected.com/3-ways-to-write-a-calculator-in-python-61642f2e4a9a 
 '''
-def Calendar():
-    now = datetime.datetime.now()
-    return f'Today is {calendar.day_name[now.weekday()]}, {calendar.month_name[now.month]} {now.day}, {now.year}'
+def Calculator(input_query: str):
+    operators = {
+        '+': add,
+        '-': sub,
+        '*': mul,
+        '/': truediv
+        }
+    if input_query.isdigit():
+        return float(input_query)
+    for c in operators.keys():
+        left, operator, right = input_query.partition(c)
+        if operator in operators:
+            return operators[operator](Calculator(left), Calculator(right))
 
 
-# WIP
-def question_answering_system():
-    pass
+# Other Optional Tools
 
 
-# Other Optional Search Tools
+'''
+Wolfram Alpha Calculator
+
+pip install wolframalpha
+
+Uses Wolfram Alpha API to calculate input query.
+
+input_query - A string, the input query (e.g. "what is 2 + 2?")
+
+output - A string, the answer to the input query
+
+wolfarm_alpha_appid - your Wolfram Alpha API key
+'''
+def WolframAlphaCalculator(input_query: str):
+    wolfram_alpha_appid = 'YOUR_WOLFRAM_ALPHA_APPID'
+    wolfram_client = wolframalpha.Client(wolfram_alpha_appid)
+    res = wolfram_client.query(input_query)
+    assumption = next(res.pods).text
+    answer = next(res.results).text
+    return f'Assumption: {assumption} \nAnswer: {answer}'
+
 
 '''
 Google Search
@@ -125,8 +150,10 @@ def custom_search(query, api_key, cse_id, **kwargs):
     res = service.cse().list(q=query, cx=cse_id, **kwargs).execute()
     return res['items']
 
-def google_search(input_query: str, api_key: str, cse_id: str, num_results: int = 10):
-    """Searches the API for the query."""
+def google_search(input_query: str):
+    api_key = "YOUR_GOOGLE_API_KEY"
+    cse_id = 'YOUR_GOOGLE_CSE_ID' 
+    num_results = 10
     metadata_results = []
     results = custom_search(input_query, num=num_results, api_key=api_key, cse_id=cse_id)
     for result in results:
@@ -165,7 +192,9 @@ def _bing_search_results(search_term: str, bing_subscription_key: str, count: in
     search_results = response.json()
     return search_results["webPages"]["value"]
 
-def bing_search(input_query: str, bing_subscription_key: str, num_results: int):
+def bing_search(input_query: str):
+    bing_subscription_key = "YOUR BING API KEY" 
+    num_results = 10
     metadata_results = []
     results = _bing_search_results(input_query, bing_subscription_key, count=num_results)
     for result in results:
@@ -179,16 +208,22 @@ def bing_search(input_query: str, bing_subscription_key: str, num_results: int):
 
 
 if __name__ == '__main__':
-    
-    print(Calculator('What is 2 + 2?')) # 4
-    
-    print(WikiSearch('what is a dog?')) # Outputs a list of strings, each string is a Wikipedia document
+ 
+    print(Calendar()) # Outputs a string, the current date
+
+    print(Calculator('400/1400')) # For Optional Basic Calculator
+
+    print(WikiSearch('What is a dog?')) # Outputs a list of strings, each string is a Wikipedia document
 
     print(MT("Un chien c'est quoi?")) # What is a dog?
 
-    print(Calendar()) # Outputs a string, the current date
 
     # Optional Tools
-    print(google_search('what is a dog?', api_key="YOUR_GOOGLE_API_KEY", cse_id="YOUR_CSE_ID", num_results=10)) # Outputs a list of dictionaries, each dictionary is a Google Search result
 
-    print(bing_search('what is a dog?', bing_subscription_key="YOUR_BING_API_KEY", num_results=10)) # Outputs a list of dictionaries, each dictionary is a Bing Search result
+    print(WolframAlphaCalculator('What is 2 + 2?')) # 4
+
+    print(google_search('What is a dog?')) 
+    # Outputs a list of dictionaries, each dictionary is a Google Search result
+
+    print(bing_search('What is a dog?')) 
+    # Outputs a list of dictionaries, each dictionary is a Bing Search result

--- a/toolformer_pytorch/tools.py
+++ b/toolformer_pytorch/tools.py
@@ -1,5 +1,7 @@
 import requests
+import calendar
 import wolframalpha
+import datetime
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 
 # Optional Tool imports
@@ -19,7 +21,8 @@ output - A string, the answer to the input query
 
 wolfarm_alpha_appid - your Wolfram Alpha API key
 '''
-def calculator(input_query: str, wolfram_alpha_appid: str):
+def Calculator(input_query: str):
+    wolfram_alpha_appid = 'YOUR_WOLFRAM_ALPHA_APPID'
     wolfram_client = wolframalpha.Client(wolfram_alpha_appid)
     res = wolfram_client.query(input_query)
     assumption = next(res.pods).text
@@ -57,7 +60,8 @@ def colbertv2_get_request(url: str, query: str, k: int):
     topk = res.json()['topk'][:k]
     return topk
 
-def wikipedia_search(input_query: str, k: int = 10):
+def WikiSearch(input_query: str):
+    k = 10
     retrieval_model = ColBERTv2('http://ec2-44-228-128-229.us-west-2.compute.amazonaws.com:8893/api/search')
     output = retrieval_model(input_query, k)
     return output
@@ -72,7 +76,8 @@ input_query - A string, the input query (e.g. "what is a dog?")
 
 output - A string, the translated input query.
 '''
-def machine_translation_system(input_query: str, model_name: str = "facebook/nllb-200-distilled-600M"):
+def MT(input_query: str):
+    model_name = "facebook/nllb-200-distilled-600M"
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     model = AutoModelForSeq2SeqLM.from_pretrained(model_name)
     input_ids = tokenizer(input_query, return_tensors='pt')
@@ -83,13 +88,21 @@ def machine_translation_system(input_query: str, model_name: str = "facebook/nll
     output = tokenizer.batch_decode(outputs, skip_special_tokens=True)[0]
     return output
 
+
+'''
+Calendar
+
+Uses Python's datetime and calendar libraries to retrieve the current date.
+
+output - A string, the current date.
+'''
+def Calendar():
+    now = datetime.datetime.now()
+    return f'Today is {calendar.day_name[now.weekday()]}, {calendar.month_name[now.month]} {now.day}, {now.year}'
+
+
 # WIP
 def question_answering_system():
-    pass
-
-
-# WIP
-def calendar():
     pass
 
 
@@ -167,11 +180,13 @@ def bing_search(input_query: str, bing_subscription_key: str, num_results: int):
 
 if __name__ == '__main__':
     
-    print(calculator('What is 2 + 2?', 'YOUR_API_KEY_HERE')) # 4
+    print(Calculator('What is 2 + 2?')) # 4
     
-    print(wikipedia_search('what is a dog?', k=10)) # Outputs a list of strings, each string is a Wikipedia document
+    print(WikiSearch('what is a dog?')) # Outputs a list of strings, each string is a Wikipedia document
 
-    print(machine_translation_system("Un chien c'est quoi?")) # What is a dog?
+    print(MT("Un chien c'est quoi?")) # What is a dog?
+
+    print(Calendar()) # Outputs a string, the current date
 
     # Optional Tools
     print(google_search('what is a dog?', api_key="YOUR_GOOGLE_API_KEY", cse_id="YOUR_CSE_ID", num_results=10)) # Outputs a list of dictionaries, each dictionary is a Google Search result

--- a/toolformer_pytorch/tools.py
+++ b/toolformer_pytorch/tools.py
@@ -1,0 +1,179 @@
+import requests
+import wolframalpha
+from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+
+# Optional Tool imports
+from googleapiclient.discovery import build
+
+
+'''
+Calculator
+
+pip install wolframalpha
+
+Uses Wolfram Alpha API to calculate input query.
+
+input_query - A string, the input query (e.g. "what is 2 + 2?")
+
+output - A string, the answer to the input query
+
+wolfarm_alpha_appid - your Wolfram Alpha API key
+'''
+def calculator(input_query: str, wolfram_alpha_appid: str):
+    wolfram_client = wolframalpha.Client(wolfram_alpha_appid)
+    res = wolfram_client.query(input_query)
+    assumption = next(res.pods).text
+    answer = next(res.results).text
+    return f'Assumption: {assumption} \nAnswer: {answer}'
+
+
+'''
+Wikipedia Search
+
+Uses ColBERTv2 to retrieve Wikipedia documents.
+
+input_query - A string, the input query (e.g. "what is a dog?")
+k - The number of documents to retrieve
+
+output - A list of strings, each string is a Wikipedia document
+
+Adapted from Stanford's DSP: https://github.com/stanfordnlp/dsp/
+Also see: https://github.com/lucabeetz/dsp
+'''
+class ColBERTv2:
+    def __init__(self, url: str):
+        self.url = url
+
+    def __call__(self, query, k=10):
+        topk = colbertv2_get_request(self.url, query, k)
+
+        topk = [doc['text'] for doc in topk]
+        return topk
+
+def colbertv2_get_request(url: str, query: str, k: int):
+    payload = {'query': query, 'k': k}
+    res = requests.get(url, params=payload)
+
+    topk = res.json()['topk'][:k]
+    return topk
+
+def wikipedia_search(input_query: str, k: int = 10):
+    retrieval_model = ColBERTv2('http://ec2-44-228-128-229.us-west-2.compute.amazonaws.com:8893/api/search')
+    output = retrieval_model(input_query, k)
+    return output
+
+
+'''
+Machine Translation - NLLB-600M
+
+Uses HuggingFace's transformers library to translate input query to English.
+
+input_query - A string, the input query (e.g. "what is a dog?")
+
+output - A string, the translated input query.
+'''
+def machine_translation_system(input_query: str, model_name: str = "facebook/nllb-200-distilled-600M"):
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForSeq2SeqLM.from_pretrained(model_name)
+    input_ids = tokenizer(input_query, return_tensors='pt')
+    outputs = model.generate(
+        **input_ids,
+        forced_bos_token_id=tokenizer.lang_code_to_id["eng_Latn"], 
+        )
+    output = tokenizer.batch_decode(outputs, skip_special_tokens=True)[0]
+    return output
+
+# WIP
+def question_answering_system():
+    pass
+
+
+# WIP
+def calendar():
+    pass
+
+
+# Other Optional Search Tools
+
+'''
+Google Search
+
+Uses Google's Custom Search API to retrieve Google Search results.
+
+input_query - The query to search for.
+num_results - The number of results to return.
+api_key - Your Google API key.
+cse_id - Your Google Custom Search Engine ID.
+
+output - A list of dictionaries, each dictionary is a Google Search result
+'''
+def custom_search(query, api_key, cse_id, **kwargs):
+    service = build("customsearch", "v1", developerKey=api_key)
+    res = service.cse().list(q=query, cx=cse_id, **kwargs).execute()
+    return res['items']
+
+def google_search(input_query: str, api_key: str, cse_id: str, num_results: int = 10):
+    """Searches the API for the query."""
+    metadata_results = []
+    results = custom_search(input_query, num=num_results, api_key=api_key, cse_id=cse_id)
+    for result in results:
+        metadata_result = {
+            "snippet": result["snippet"],
+            "title": result["title"],
+            "link": result["link"],
+        }
+        metadata_results.append(metadata_result)
+    return metadata_results
+
+
+'''
+Bing Search
+
+Uses Bing's Custom Search API to retrieve Bing Search results.
+
+input_query: The query to search for.
+bing_subscription_key: Your Bing API key.
+num_results: The number of results to return.
+
+output: A list of dictionaries, each dictionary is a Bing Search result
+'''
+def _bing_search_results(search_term: str, bing_subscription_key: str, count: int):
+    headers = {"Ocp-Apim-Subscription-Key": bing_subscription_key}
+    params = {
+        "q": search_term,
+        "count": count,
+        "textDecorations": True,
+        "textFormat": "HTML",
+    }
+    response = requests.get(
+        "https://api.bing.microsoft.com/v7.0/search", headers=headers, params=params
+    )
+    response.raise_for_status()
+    search_results = response.json()
+    return search_results["webPages"]["value"]
+
+def bing_search(input_query: str, bing_subscription_key: str, num_results: int):
+    metadata_results = []
+    results = _bing_search_results(input_query, bing_subscription_key, count=num_results)
+    for result in results:
+        metadata_result = {
+            "snippet": result["snippet"],
+            "title": result["name"],
+            "link": result["url"],
+        }
+        metadata_results.append(metadata_result)
+    return metadata_results
+
+
+if __name__ == '__main__':
+    
+    print(calculator('What is 2 + 2?', 'YOUR_API_KEY_HERE')) # 4
+    
+    print(wikipedia_search('what is a dog?', k=10)) # Outputs a list of strings, each string is a Wikipedia document
+
+    print(machine_translation_system("Un chien c'est quoi?")) # What is a dog?
+
+    # Optional Tools
+    print(google_search('what is a dog?', api_key="YOUR_GOOGLE_API_KEY", cse_id="YOUR_CSE_ID", num_results=10)) # Outputs a list of dictionaries, each dictionary is a Google Search result
+
+    print(bing_search('what is a dog?', bing_subscription_key="YOUR_BING_API_KEY", num_results=10)) # Outputs a list of dictionaries, each dictionary is a Bing Search result


### PR DESCRIPTION
Hi Phil,

In this PR I have added a GPTJ architecture, prompts, and tooling for the Calculator, Wikipedia Search, Machine Translation System, Calendar, and other optional tools such as Wolfram Alpha, Google, and Bing Search.

The Calculator can perform simple numeric calculations supporting the four basic arithmetic operations.

The Wikipedia Search tool uses the ColBERTv2 retrieval model and a Wikipedia database hosted by Stanford. Given a search term, returns short text snippets from Wikipedia.

The Machine Translation System uses NLLB-600M to translate a phrase from any language into English.

The Calendar returns the current date without taking any input.

Optional:

The Wolfram Alpha Calculator utilizes the Wolfram Alpha API to solve math-related questions. This would allow for more complex numeric calculations.

Google and Bing Search which when given a query return relevant titles, snippets, and links from the search results.

I am working on adding Atlas and possibly Google Calendar.

I hope some of this is helpful. Let me know if you want anything changed or removed.

Thank you,

Enrico