### PR TITLE
api_stop in invoke_tools has extra space

### DIFF
--- a/toolformer_pytorch/toolformer_pytorch.py
+++ b/toolformer_pytorch/toolformer_pytorch.py
@@ -192,7 +192,7 @@ def invoke_tools(
     text: str,
     delimiter: str = '→',
     api_start = ' [',
-    api_stop = ' ]'
+    api_stop = ']'
 ) -> str:
     regex = create_function_regex(api_start, api_stop)
     replace_ = partial(replace_fn, registry, delimiter = delimiter)


### PR DESCRIPTION
The extra space leads to different regex so tools are not invoked.
addressing https://github.com/lucidrains/toolformer-pytorch/issues/19